### PR TITLE
Fix input devices, non-ascii char in name

### DIFF
--- a/pulsemixer
+++ b/pulsemixer
@@ -1245,7 +1245,7 @@ class Bar():
             name = pa.description.decode()
         else:
             name = pa.client.name.decode()
-        return b64encode(bytes(name + str(pa.index) + pa.__class__.__name__, 'ascii'))
+        return b64encode(bytes(name + str(pa.index) + pa.__class__.__name__, 'utf-8'))
 
     def pollData(self, pa):
         self.channels = pa.volume.channels


### PR DESCRIPTION
Microsoft® LifeCam 
UnicodeEncodeError: 'ascii' codec can't encode character '\xae' in position 9: ordinal not in range(128)