### PR TITLE
Fix typo making pa_mainloop_free actually call pa_mainloop_run

### DIFF
--- a/pulsemixer
+++ b/pulsemixer
@@ -304,7 +304,7 @@ pa_mainloop_dispatch = p.pa_mainloop_dispatch
 pa_mainloop_dispatch.restype = c_int
 pa_mainloop_dispatch.argtypes = [POINTER(PA_MAINLOOP)]
 
-pa_mainloop_free = p.pa_mainloop_run
+pa_mainloop_free = p.pa_mainloop_free
 pa_mainloop_free.restype = c_int
 pa_mainloop_free.argtypes = [POINTER(PA_MAINLOOP)]
 


### PR DESCRIPTION
Only realized it when seeing *_free never run in gdb, when trying to debug mem/fd leaks, and after haphazardly applying `pa_mainloop_quit(loop, 0)` hack to make libpulse exit cleanly (and not hang) at all.

Thanks for taking your time to make a proper pa cli mixer.

Mostly unrelated to the issue itself:
I'm currently in need of a module to control pulse from py again, won't try dbus there for sure (has a ton of issues), and found bindings + lib in your code as the most compact and nice solution, so split these (with modifications) into separate module - https://github.com/mk-fg/python-pulse-control - hope you don't mind.
