### PR TITLE
only run in real terminals

### DIFF
--- a/pulsemixer
+++ b/pulsemixer
@@ -1773,7 +1773,7 @@ def main():
     global pulse
     pulse = Pulse('pulsemixer', server)
 
-    if len(sys.argv) == 1 or (len(dopts) == 1 and server):
+    if sys.stdout.isatty() and (len(sys.argv) == 1 or (len(dopts) == 1 and server)):
         curses.wrapper(Screen().run)
 
     sinks = pulse.sink_list()


### PR DESCRIPTION
I think this fixes #22.
It might just be a workaround as the underlying memory leak in the curses code still exists but it will not trigger as it only runs in real terminals.