### PR TITLE
Add support for snaps

### DIFF
--- a/snap/scripts/launcher
+++ b/snap/scripts/launcher
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+if [ "$SNAP_ARCH" == "amd64" ]; then
+  ARCH="x86_64-linux-gnu"
+elif [ "$SNAP_ARCH" == "armhf" ]; then
+  ARCH="arm-linux-gnueabihf"
+elif [ "$SNAP_ARCH" == "arm64" ]; then
+  ARCH="aarch64-linux-gnu"
+else
+  ARCH="$SNAP_ARCH-linux-gnu"
+fi
+
+# Pulseaudio export
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$SNAP/usr/lib/$ARCH/pulseaudio
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$SNAP/lib/$ARCH
+
+exec "$@"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -20,7 +20,7 @@ parts:
   pulsemixer:
     plugin: python
     python-version: python3
-    source: https://github.com/GeorgeFilipkin/pulsemixer.git
+    source: .
     stage-packages:
       - libpulse0
     filesets:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,82 @@
+name: pulsemixer
+version: git
+summary: cli and curses mixer for pulseaudio
+description: |
+  cli and curses mixer for pulseaudio.
+
+confinement: strict
+
+apps:
+  pulsemixer:
+    command: launcher $SNAP/bin/pulsemixer
+    environment:
+      LC_ALL: C.UTF-8
+    plugs:
+      - network
+      - pulseaudio
+      - x11
+
+parts:
+  pulsemixer:
+    plugin: python
+    python-version: python3
+    source: https://github.com/GeorgeFilipkin/pulsemixer.git
+    stage-packages:
+      - libpulse0
+    filesets:
+      cruft_compilers_and_debuggers:
+        - -usr/bin/pdb3*
+      cruft_debhelper:
+        - -usr/bin/dh_*
+        - -usr/share/debhelper
+        - -usr/share/dh-python
+        - -usr/share/perl5/Debian
+      cruft_docs:
+        - -usr/share/doc
+        - -usr/share/doc-base
+      cruft_lintian:
+        - -usr/share/lintian/overrides
+      cruft_man_pages:
+        - -usr/share/man
+        - -share/man
+      cruft_meta:
+        - -usr/share/applications
+        - -usr/share/pixmaps
+      cruft_python_2to3:
+        - -usr/bin/2to3*
+        - -usr/lib/python*/lib2to3
+      cruft_python_idle:
+        - -usr/lib/python*/idlelib
+        - -usr/lib/python*/tkinter
+      cruft_python_pip:
+        - -lib/python*/site-packages/pip
+      cruft_python_setuptools:
+        - -lib/python*/site-packages/setuptools*
+      cruft_python_tests:
+        - -lib/python*/site-packages/tests
+      cruft_python_venv:
+        - -usr/lib/python*/venv
+      cruft_python_wheel:
+        - -lib/python*/site-packages/wheel*
+      cruft_x11:
+        - -usr/share/X11/XErrorDB
+    prime:
+      - $cruft_compilers_and_debuggers
+      - $cruft_debhelper
+      - $cruft_docs
+      - $cruft_lintian
+      - $cruft_man_pages
+      - $cruft_meta
+      - $cruft_python_2to3
+      - $cruft_python_idle
+      - $cruft_python_pip
+      - $cruft_python_setuptools
+      - $cruft_python_tests
+      - $cruft_python_venv
+      - $cruft_python_wheel
+      - $cruft_x11
+  launcher:
+    plugin: dump
+    source: snap/scripts
+    organize:
+      'launcher': bin/


### PR DESCRIPTION
This pull request adds support to build pulsemixer as a snap.

Pulsemixer is already [available](https://snapcraft.io/pulsemixer/) in the snap store via the yaml in the [snapcrafter](https://github.com/snapcrafters/pulsemixer). Since 17.10, pulsemixer has been installed in the Ubuntu MATE flavour as a default application, and is thus installed on thousands of computers as a result. 

This PR is to upstream the snapcraft.yaml which creates the snap which is in the store. If the PR is accepted, we can transfer ownership of the pulsemixer snap to you, the upstream developer. Once done you could use the free build.snapcraft.io service to automatically build new releases of pulsemixer and push directly to the store. 

If accepted, I'm happy to walk you through the next steps. 