### PR TITLE
Limit maximum volume with --max-volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Usage of pulsemixer:
   --set-volume n        set volume for ID
   --set-volume-all n:n  set volume for ID (for every channel)
   --change-volume +-n   change volume for ID
+  --max-volume n        set volume to n if volume is higher than n
   --get-mute            get mute for ID
   --toggle-mute         toggle mute for ID
   --get-volume          get volume for ID

--- a/pulsemixer
+++ b/pulsemixer
@@ -9,6 +9,7 @@
   --set-volume n        set volume for ID
   --set-volume-all n:n  set volume for ID (for every channel)
   --change-volume +-n   change volume for ID
+  --max-volume n        set volume to n if volume is higher than n
   --get-mute            get mute for ID
   --toggle-mute         toggle mute for ID
   --get-volume          get volume for ID
@@ -1883,7 +1884,7 @@ def main():
             ["help", "version", "list", "list-sinks", "list-sources", "id=",
              "set-volume=", "set-volume-all=", "change-volume=", "get-volume",
              "get-mute", "toggle-mute", "mute", "unmute", "create-config",
-             "color=", "server=", "no-mouse"])
+             "color=", "server=", "no-mouse", "max-volume="])
     except getopt.GetoptError as e:
         sys.exit("ERR: {}".format(e))
     assert args == [], sys.exit('ERR: {} not not recognized'.format(' '.join(args).strip()))
@@ -2009,6 +2010,13 @@ def main():
             vol = streams[index].volume
             for i, _ in enumerate(vol.values):
                 vol.values[i] += int(arg)
+            PULSE.set_volume(streams[index], vol)
+
+        elif opt == '--max-volume':
+            check_n(arg, err='max volume')
+            vol = streams[index].volume
+            for i, _ in enumerate(vol.values):
+                vol.values[i] = min(vol.values[i], int(arg))
             PULSE.set_volume(streams[index], vol)
 
 


### PR DESCRIPTION
I mainly use pulsemixer bound to keys for changing volume up or down. I mostly change volume "blindly", not knowing exacty what volume I am at, but I don't want to go past 100% to avoid distortion.

This PR adds `--max-volume n` that sets the volume to `n` if the volume is higher than that:
```
pulsemixer --get-volume --change-volume +10 --get-volume --max-volume 100 --get-volume
95 95
105 105
100 100
```

I initially made a patch that only applied to `--change-volume`, where `--max-volume` had to be put before `--change-volume`, but this required tweaking of the `--change-volume` logic and I thought the solution in this PR was a bit more elegant. The other solution is available in https://github.com/reinefjord/pulsemixer/tree/maxvolpre if you're interested.