### PR TITLE
add renaming feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,13 @@ step-big = 10
 ; info-unlocked      = U
 ; info-muted         = M  ; 🔇
 ; info-unmuted       = M  ; 🔉
+
+[renames]
+;; Changes stream names in interactive mode, regular expression are supported
+;; https://docs.python.org/3/library/re.html#regular-expression-syntax
+; 'default name example' = 'new name'
+; '(?i)built-in .* audio' = 'Audio Controller'
+; 'AudioIPC Server' = 'Firefox'
 ```
 
 The old environment variable `PULSEMIXER_BAR_STYLE` is still supported.  

--- a/pulsemixer
+++ b/pulsemixer
@@ -1771,6 +1771,7 @@ class Config():
         self.keys = Keys()
         self.ui = UI()
         self.style = Style()
+        self.renames = {}
 
         self.path = os.getenv("XDG_CONFIG_HOME", os.path.join(os.path.expanduser("~"), ".config")) + '/pulsemixer.cfg'
         try:

--- a/pulsemixer
+++ b/pulsemixer
@@ -1838,7 +1838,10 @@ class Config():
         ; info-unmuted       = M  ; 🔉
 
         [renames]
+        ;; Changes stream names in interactive mode, regular expression are supported
+        ;; https://docs.python.org/3/library/re.html#regular-expression-syntax
         ; 'default name example' = 'new name'
+        ; '(?i)built-in .* audio' = 'Audio Controller'
         ; 'AudioIPC Server' = 'Firefox'
         '''
         directory = self.path.rsplit('/', 1)[0]

--- a/pulsemixer
+++ b/pulsemixer
@@ -947,6 +947,10 @@ class Bar():
         else:
             self.fullname = pa.client.name.decode()
         self.name = re.sub(r'^ALSA plug-in \[|\]$', '', self.fullname.replace('|', ' '))
+        for key in CFG.renames:
+            if key.match(self.name):
+                self.name = CFG.renames[key]
+                break
         self.index = pa.index
         self.owner = -1
         self.stream_index = -1
@@ -1537,8 +1541,7 @@ class Screen():
             if bartype is Bar.LEFT:
                 if bar.pa.name in (self.server_info.default_sink_name, self.server_info.default_source_name):
                     tree = CFG.style.default_stream
-                barname = CFG.renames.get(bar.name, bar.name)
-                name = '{}{}'.format(barname, bar.media_name)
+                name = '{}{}'.format(bar.name, bar.media_name)
                 name = name[:20 + off] + '~' if len(name) > 20 + off else name
                 line = '{:<{}}|{}\n {:<3}|{}\n '.format(name, 22 + off, focus_hl,
                                                         '' if type(bar.pa) is PulseCard else bar.volume[0],
@@ -1850,7 +1853,7 @@ class Config():
         parser.optionxform = str  # keep case of keys, lowered() later
         if not parser.read(self.path): return
         if parser.has_section('renames'):
-            self.renames = {k.strip('"\''):v.strip('"\'') for k, v in parser.items('renames')}
+            self.renames = {re.compile(k.strip('"\'') + r'\Z'):v.strip('"\'') for k, v in parser.items('renames')}
             parser.remove_section('renames')
         def getkeys(s, k):
             keys = []

--- a/pulsemixer
+++ b/pulsemixer
@@ -41,6 +41,7 @@ from select import select
 from shutil import get_terminal_size
 from textwrap import dedent
 from time import sleep
+from ast import literal_eval
 
 #########################################################################################
 # v bindings
@@ -1537,7 +1538,11 @@ class Screen():
             if bartype is Bar.LEFT:
                 if bar.pa.name in (self.server_info.default_sink_name, self.server_info.default_source_name):
                     tree = CFG.style.default_stream
-                name = '{}{}'.format(bar.name, bar.media_name)
+                barname = bar.name
+                for key in CFG.renames:
+                    if key == barname:
+                        barname = CFG.renames[key]
+                name = '{}{}'.format(barname, bar.media_name)
                 name = name[:20 + off] + '~' if len(name) > 20 + off else name
                 line = '{:<{}}|{}\n {:<3}|{}\n '.format(name, 22 + off, focus_hl,
                                                         '' if type(bar.pa) is PulseCard else bar.volume[0],
@@ -1782,7 +1787,7 @@ class Config():
         [general]
         step = 1
         step-big = 10
-        ; server = 
+        ; server =
 
         [keys]
         ;; To bind "special keys" such as arrows see "Key constant" table in
@@ -1842,6 +1847,9 @@ class Config():
     def load(self):
         parser = ConfigParser(inline_comment_prefixes=('#', ';'))
         if not parser.read(self.path): return
+        if parser.has_section('renames'):
+            self.renames = literal_eval(parser['renames']['renames'])
+            parser.remove_section('renames')
         def getkeys(s, k):
             keys = []
             for i in parser.get(s, k).strip(',').split(','):

--- a/pulsemixer
+++ b/pulsemixer
@@ -1836,6 +1836,13 @@ class Config():
         ; info-unlocked      = U
         ; info-muted         = M  ; 🔇
         ; info-unmuted       = M  ; 🔉
+
+        ;[renames]
+        ;renames: {
+        ;    'default name example': 'new name',
+        ;    'AudioIPC Server': 'FireFox',
+        ;    }
+
         '''
         directory = self.path.rsplit('/', 1)[0]
         if not os.path.exists(directory):

--- a/pulsemixer
+++ b/pulsemixer
@@ -41,7 +41,6 @@ from select import select
 from shutil import get_terminal_size
 from textwrap import dedent
 from time import sleep
-from ast import literal_eval
 
 #########################################################################################
 # v bindings
@@ -1538,10 +1537,7 @@ class Screen():
             if bartype is Bar.LEFT:
                 if bar.pa.name in (self.server_info.default_sink_name, self.server_info.default_source_name):
                     tree = CFG.style.default_stream
-                barname = bar.name
-                for key in CFG.renames:
-                    if key == barname:
-                        barname = CFG.renames[key]
+                barname = CFG.renames.get(bar.name, bar.name)
                 name = '{}{}'.format(barname, bar.media_name)
                 name = name[:20 + off] + '~' if len(name) > 20 + off else name
                 line = '{:<{}}|{}\n {:<3}|{}\n '.format(name, 22 + off, focus_hl,
@@ -1838,12 +1834,9 @@ class Config():
         ; info-muted         = M  ; 🔇
         ; info-unmuted       = M  ; 🔉
 
-        ;[renames]
-        ;renames: {
-        ;    'default name example': 'new name',
-        ;    'AudioIPC Server': 'FireFox',
-        ;    }
-
+        [renames]
+        ; 'default name example' = 'new name'
+        ; 'AudioIPC Server' = 'Firefox'
         '''
         directory = self.path.rsplit('/', 1)[0]
         if not os.path.exists(directory):
@@ -1854,9 +1847,10 @@ class Config():
 
     def load(self):
         parser = ConfigParser(inline_comment_prefixes=('#', ';'))
+        parser.optionxform = str  # keep case of keys, lowered() later
         if not parser.read(self.path): return
         if parser.has_section('renames'):
-            self.renames = literal_eval(parser['renames']['renames'])
+            self.renames = {k.strip('"\''):v.strip('"\'') for k, v in parser.items('renames')}
             parser.remove_section('renames')
         def getkeys(s, k):
             keys = []
@@ -1879,7 +1873,7 @@ class Config():
                int: parser.getint, float: parser.getfloat}
         for section in parser.sections():
             for key in parser[section]:
-                pykey = key.replace('-', '_')
+                pykey = key.lower().replace('-', '_')
                 pyval = getattr(getattr(self, section.lower()), pykey)
                 val = get[type(pyval)](section, key)
                 setattr(getattr(self, section.lower()), pykey, val)

--- a/pulsemixer
+++ b/pulsemixer
@@ -965,11 +965,11 @@ class Bar():
         self.owned = owned
         self.stream_index = stream_index
         self.volume = pa.volume.values
-        try:
+        if hasattr(pa, 'media_name'):
             media_name = pa.media_name.decode().replace('|', ' ')
-            if self.name != media_name:
+            if self.fullname != media_name:
                 self.media_name = ': {}'.format(media_name)
-        except:
+        else:
             self.media_name = ''
         if type(pa) in (PulseSinkInputInfo, PulseSourceOutputInfo):
             self.owner = pa.owner
@@ -1173,9 +1173,9 @@ class Screen():
             return
         side = 'All' if bar.locked else 'Mono' if bar.channels == 1 else self.SIDES[side]
         more = '↕' if bottom < self.n_lines and self.top_line_num > 0 else '↑' if self.top_line_num > 0 else '↓' if bottom < self.n_lines else ' '
-        name = '{}: {}'.format(bar.fullname, side)
+        name = '{}: {}'.format(bar.name, side)
         if len(name) > self.cols - 8:
-            name = '{}: {}'.format(bar.fullname[:self.cols - (10 + len(side))].strip(), side)
+            name = '{}: {}'.format(bar.name[:self.cols - (10 + len(side))].strip(), side)
         locked = '{}|{}'.format(CFG.style.info_locked, self.red) if bar.locked else '{}|{}'.format(CFG.style.info_unlocked, curses.A_DIM)
         muted  = '{}|{}'.format(CFG.style.info_muted, self.red) if bar.muted else '{}|{}'.format(CFG.style.info_unmuted, curses.A_DIM)
         self.info = '{}\n {}\n  {}|{}\n{:>{}}|0'.format(locked, muted, name, curses.A_NORMAL, more, self.cols - len(name) - 5)


### PR DESCRIPTION
needs more work to make it so you don't have to add the same name twice,
once with with "<Analog/Digital> <Sterio/Mono>" prefix and once without.
I didn't want to modify the library code to get `device.profile.description` and remove it from name.
```
[auser@archmachine ~]$ pactl list sinks | grep Stereo
        Description: ATR USB microphone Analog Stereo
                device.profile.description = "Analog Stereo"
                device.description = "ATR USB microphone Analog Stereo"
        Description: Built-in Audio Analog Stereo
                device.profile.description = "Analog Stereo"
                device.description = "Built-in Audio Analog Stereo"
        Description: GP106 High Definition Audio Controller Digital Stereo (HDMI)
                device.profile.description = "Digital Stereo (HDMI)"
                device.description = "GP106 High Definition Audio Controller Digital Stereo (HDMI)"

```

here's how I found it useful, from my config file:
```
 [renames]
renames: {
    'AudioIPC Server': 'FireFox',
    'mpv Media Player': 'MPV',
    'Music Player Daemon': 'MPD',
    'ATR USB microphone': 'ATR mic',
    'ATR USB microphone Analog Stereo': 'ATR mic',
    'GP106 High Definition Audio Controller': 'GTX1060 HD Audio Controller',
    'GP106 High Definition Audio Controller Digital Stereo (HDMI)': 'GTX1060 HD Audio Controller'
    }

```
