### PR TITLE
fix resizing upon winch events

### DIFF
--- a/pulsemixer
+++ b/pulsemixer
@@ -36,9 +36,9 @@ from collections import OrderedDict
 from configparser import ConfigParser
 from ctypes import *
 from itertools import takewhile
+from os import get_terminal_size
 from pprint import pprint
 from select import select
-from shutil import get_terminal_size
 from textwrap import dedent
 from time import sleep
 from unicodedata import east_asian_width


### PR DESCRIPTION
`shutil.get_terminal_size` doesn't seem to update when threading is
involved so just use `os.get_terminal_size` instead.

I'm using:
GNU/Linux (Arch distro)
Python 3.8.1
pulsemixer 1.5.1

I've tried using several terminal emulators, with and without tmux, and in each of these scenarios pulsemixer refuses to resize when I resize my terminal emulator window or tmux pane. This is a pretty simple fix, so hopefully it's acceptable.