### PR TITLE
Fixes to work on OSX

### DIFF
--- a/pulsemixer
+++ b/pulsemixer
@@ -47,7 +47,10 @@ from unicodedata import east_asian_width
 # v bindings
 
 try:
-    DLL = CDLL("libpulse.so.0")
+    if sys.platform == "darwin":
+        DLL = CDLL("libpulse.dylib")
+    else:
+        DLL = CDLL("libpulse.so.0")
 except Exception as e:
     sys.exit(e)
 

--- a/pulsemixer
+++ b/pulsemixer
@@ -940,7 +940,10 @@ class Bar():
             self.name = pa
             return
         if type(pa) in (PulseSinkInfo, PulseSourceInfo, PulseCard):
-            self.fullname = pa.description.decode()
+            if pa.description:
+                self.fullname = pa.description.decode()
+            else:
+                self.fullname = pa.name.decode()
         else:
             self.fullname = pa.client.name.decode()
         self.name = re.sub(r'^ALSA plug-in \[|\]$', '', self.fullname.replace('|', ' '))


### PR DESCRIPTION
* Loads appropriate pulseaudio dylib
* Fixes the following bug

```
$ ./pulsemixer 
Traceback (most recent call last):
  File "./pulsemixer", line 2057, in <module>
    main()
  File "./pulsemixer", line 1951, in main
    curses.wrapper(Screen(CFG.ui.color, CFG.ui.mouse).run)
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/curses/__init__.py", line 94, in wrapper
    return func(stdscr, *args, **kwds)
  File "./pulsemixer", line 1292, in run
    self.change_mode(2)
  File "./pulsemixer", line 1146, in change_mode
    self.get_data()
  File "./pulsemixer", line 1458, in get_data
    self.data = self.build(self.modes_data[2][0], PULSE.card_list(), [])
  File "./pulsemixer", line 1421, in build
    bar = Bar(s[0])
  File "./pulsemixer", line 943, in __init__
    self.fullname = pa.description.decode()
AttributeError: 'NoneType' object has no attribute 'decode'
```

pulseaudio version (installed via homebrew):

```
$ pulseaudio --version
W: [] caps.c: Normally all extra capabilities would be dropped now, but that's impossible because PulseAudio was built without capabilities support.
pulseaudio 13.0
```