### PR TITLE
Make explicit that this script does not use any packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ setup(name='pulsemixer',
     author='George Filipkin',
     author_email='botebotebot@gmail.com',
     license='MIT',
+    packages=[],
     scripts=['pulsemixer'],
     classifiers=[
         'Environment :: Console',


### PR DESCRIPTION
The 'snap' directory is for distribution, but not needed for the script to run. For Debian packaging, a `debian` directory is added with a similar purpose.
Likely since setuptools version 61, this causes an error, so specify explicitly that this script does not use any packages.

Link: https://bugs.debian.org/1022496