### PR TITLE
Fix multichannel interfaces

### DIFF
--- a/pulsemixer
+++ b/pulsemixer
@@ -930,7 +930,7 @@ class PulseVolume(DebugMixin):
 
 class Bar():
     # should be in correct order
-    LEFT, RIGHT, RLEFT, RRIGHT, CENTER, SUB, SLEFT, SRIGHT, NONE = range(9)
+    NONE, LEFT, RIGHT, RLEFT, RRIGHT, CENTER, SUB, SLEFT, SRIGHT = range(-1, 8)
 
     def __init__(self, pa):
         if type(pa) is str:
@@ -1170,7 +1170,7 @@ class Screen():
         if side is Bar.NONE:
             self.info = str
             return
-        side = 'All' if bar.locked else 'Mono' if bar.channels == 1 else self.SIDES[side]
+        side = 'All' if bar.locked else 'Mono' if bar.channels == 1 else self.SIDES.get(side, str(side))
         more = '↕' if bottom < self.n_lines and self.top_line_num > 0 else '↑' if self.top_line_num > 0 else '↓' if bottom < self.n_lines else ' '
         name = '{}: {}'.format(bar.name, side)
         if len(name) > self.cols - 8:

--- a/pulsemixer
+++ b/pulsemixer
@@ -1159,6 +1159,11 @@ class Screen():
             selected = 'output' if type(self.selected[0].pa) is PulseSinkInputInfo else 'input'
             self.menu = "Select new {} device:|{}".format(selected, curses.A_NORMAL)
 
+    @staticmethod
+    def format_side(side):
+        name = Screen.SIDES.get(side, None)
+        return '%d (%s)' % (side, name) if name is not None else str(side)
+
     def update_info(self):
         focus, bottom = self.focus_line_num + self.top_line_num + 1, self.top_line_num + self.lines
         try:
@@ -1170,7 +1175,7 @@ class Screen():
         if side is Bar.NONE:
             self.info = str
             return
-        side = 'All' if bar.locked else 'Mono' if bar.channels == 1 else self.SIDES.get(side, str(side))
+        side = 'All' if bar.locked else 'Mono' if bar.channels == 1 else Screen.format_side(side)
         more = '↕' if bottom < self.n_lines and self.top_line_num > 0 else '↑' if self.top_line_num > 0 else '↓' if bottom < self.n_lines else ' '
         name = '{}: {}'.format(bar.name, side)
         if len(name) > self.cols - 8:


### PR DESCRIPTION
This implements

* A bug fix causing pulsemixer not to work with devices with more than 8 channels
* A QoL feature for such audio interfaces: always displaying the channel number